### PR TITLE
Adapt scanning to user-defined timeframe

### DIFF
--- a/src/components/AnalysisResults.tsx
+++ b/src/components/AnalysisResults.tsx
@@ -76,6 +76,8 @@ const AnalysisResults: React.FC<AnalysisResultsProps> = ({ result }) => {
               <span className="text-sm text-gray-400">{result.pair}</span>
               <div className="w-1 h-1 bg-gray-500 rounded-full"></div>
               <span className="text-sm text-gray-400">{result.broker.toUpperCase()}</span>
+              <div className="w-1 h-1 bg-gray-500 rounded-full"></div>
+              <span className="text-sm text-gray-400">{result.timeframe}</span>
             </div>
             <div className="flex items-center space-x-2">
               <span className="text-lg font-bold text-emerald-400">${result.entryPrice.toFixed(6)}</span>

--- a/src/components/TradingControls.tsx
+++ b/src/components/TradingControls.tsx
@@ -320,16 +320,10 @@ const TradingControls: React.FC<TradingControlsProps> = ({
       
       {/* Analyze Button */}
       <button
-        onClick={() => {
-          // Set timeframe to daily before analysis
-          if (selectedTimeframe !== '1d') {
-            onTimeframeChange('1d');
-          }
-          onAnalyze();
-        }}
+        onClick={onAnalyze}
         className="w-full bg-gradient-to-r from-emerald-600 to-blue-600 hover:from-emerald-700 hover:to-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200 transform hover:scale-105 shadow-lg"
       >
-        🚀 Analyze Market & Get Recommendation (Daily Chart)
+        🚀 Analyze Market & Get Recommendation ({selectedTimeframe} Chart)
       </button>
       
       <div className="text-xs text-gray-400 text-center mt-2">


### PR DESCRIPTION
Allow user-selected timeframes to be used for market analysis and persisted in URLs.

Previously, the "Analyze" button hardcoded the timeframe to '1d', overriding the user's selection. This PR fixes that, ensuring the user-selected timeframe is respected for analysis, displayed in the results, and persisted in the URL for shareability.

---
<a href="https://cursor.com/background-agent?bcId=bc-d00625ff-ae1b-409b-9abe-495712c62f0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d00625ff-ae1b-409b-9abe-495712c62f0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>