### PR TITLE
Ayusin ang scan result para sa future trade

### DIFF
--- a/src/components/AnalysisResults.tsx
+++ b/src/components/AnalysisResults.tsx
@@ -79,6 +79,14 @@ const AnalysisResults: React.FC<AnalysisResultsProps> = ({ result }) => {
               <span className="text-sm text-gray-400">{result.broker.toUpperCase()}</span>
               <div className="w-1 h-1 bg-gray-500 rounded-full"></div>
               <span className="text-sm text-gray-400">{result.timeframe}</span>
+              <div className="w-1 h-1 bg-gray-500 rounded-full"></div>
+              <span className={`text-sm font-medium px-2 py-1 rounded ${
+                result.tradeType === 'SPOT' 
+                  ? 'bg-emerald-600 text-emerald-100' 
+                  : 'bg-blue-600 text-blue-100'
+              }`}>
+                {result.tradeType}
+              </span>
             </div>
             <div className="flex items-center space-x-2">
               <span className="text-lg font-bold text-emerald-400">${result.entryPrice.toFixed(6)}</span>

--- a/src/components/BulkScanner.tsx
+++ b/src/components/BulkScanner.tsx
@@ -554,7 +554,16 @@ const BulkScanner: React.FC<BulkScannerProps> = ({
             {filteredResults.map((result) => (
               <div key={result.pair} className="bg-gray-700 rounded-lg p-4 space-y-3">
                 <div className="flex items-center justify-between">
-                  <h4 className="font-medium text-white">{result.pair}</h4>
+                  <div className="flex items-center space-x-2">
+                    <h4 className="font-medium text-white">{result.pair}</h4>
+                    <span className={`text-xs font-medium px-2 py-1 rounded ${
+                      result.tradeType === 'SPOT' 
+                        ? 'bg-emerald-600 text-emerald-100' 
+                        : 'bg-blue-600 text-blue-100'
+                    }`}>
+                      {result.tradeType}
+                    </span>
+                  </div>
                   <div className={`flex items-center space-x-1 ${getRecommendationColor(result.recommendation)}`}>
                     {getRecommendationIcon(result.recommendation)}
                     <span className="text-sm font-medium">{result.recommendation.replace('_', ' ')}</span>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Display the trade type (SPOT or FUTURES) in scan results to clarify which analysis type was performed.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the trade type was passed through the analysis pipeline but not visually shown, leading users to believe the system was always using SPOT, even when FUTURES was selected. This change adds clear visual indicators for the trade type in both individual and bulk scan results.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8768b35-c144-4a2e-a8fa-158bb9cc7e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8768b35-c144-4a2e-a8fa-158bb9cc7e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>